### PR TITLE
Implement bed spawn functionality

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="6fc4629d-d870-4604-ab5f-4efa61eae285" name="Changes" comment="I implemented the TeamFunctionality">
+      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnBedClickEvent.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnDeathEvent.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnTrapdoorInteractEvent.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnVillagerHitEvent.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/BedWarsPlugin.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/BedWarsPlugin.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/commands/StartRoundCommand.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/commands/StartRoundCommand.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/ItemSpawnerReader.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/ItemSpawnerReader.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/ShopItemsReader.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/ShopItemsReader.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/TeamsDataReader.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/data/TeamsDataReader.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockDestroyEvent.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockDestroyEvent.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockPlaceEvent.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockPlaceEvent.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnRespawnEvent.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/listener/OnRespawnEvent.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/BlockDeleter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/BlockDeleter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/Team.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/Team.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/TeamManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/me/daniel/bedwarsplugin/model/TeamManager.java" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ExternalProjectsData">
+    <projectState path="$PROJECT_DIR$">
+      <ProjectState />
+    </projectState>
+  </component>
+  <component name="ExternalProjectsManager">
+    <system id="GRADLE">
+      <state>
+        <task path="$PROJECT_DIR$">
+          <activation />
+        </task>
+        <projects_view>
+          <tree_state>
+            <expand>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="build" type="c8890929:TasksNode$1" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="build setup" type="c8890929:TasksNode$1" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="documentation" type="c8890929:TasksNode$1" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="help" type="c8890929:TasksNode$1" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="BedWarsPlugin" type="f1a62948:ProjectNode" />
+                <item name="Run Configurations" type="7b0102dc:RunConfigurationsNode" />
+              </path>
+            </expand>
+            <select />
+          </tree_state>
+        </projects_view>
+      </state>
+    </system>
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="JUnit5 Test Class" />
+        <option value="Class" />
+      </list>
+    </option>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="2Qz0GuIZu3DPW1Z16lnrEOd3hYJ" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
+    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
+    &quot;create.test.in.the.same.root&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;master&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/jakob/Downloads/BedWarsPlugin/BedWarsPlugin&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Problems&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.26796713&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;
+  }
+}</component>
+  <component name="RecentsManager">
+    <key name="CreateTestDialog.Recents.Supers">
+      <recent name="" />
+    </key>
+    <key name="CreateTestDialog.RecentsKey">
+      <recent name="me.daniel.bedwarsplugin" />
+    </key>
+  </component>
+  <component name="RunManager" selected="Gradle.BedWarsPlugin [build]">
+    <configuration name="BedWarsPlugin [build]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="build" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="BedWarsPlugin [clean]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="clean" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="BedWarsPlugin [dependencies]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="dependencies" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="BedWarsPlugin [jar]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="jar" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="StartSpawnerCommandTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;me.daniel.bedwarsplugin.commands.StartSpawnerCommandTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>true</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Gradle.BedWarsPlugin [build]" />
+        <item itemvalue="Gradle.BedWarsPlugin [clean]" />
+        <item itemvalue="Gradle.BedWarsPlugin [jar]" />
+        <item itemvalue="Gradle.BedWarsPlugin [dependencies]" />
+        <item itemvalue="Gradle.StartSpawnerCommandTest" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="6fc4629d-d870-4604-ab5f-4efa61eae285" name="Changes" comment="" />
+      <created>1686341011170</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1686341011170</updated>
+    </task>
+    <task id="LOCAL-00001" summary="This commit includes significant changes across multiple files in the project. The primary focus of these changes was refactoring the code to enhance its structure, readability, and maintainability. Additionally, comprehensive Javadoc comments were added to provide detailed documentation for the classes and methods involved.">
+      <created>1686346015552</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1686346015552</updated>
+    </task>
+    <task id="LOCAL-00002" summary="I implemented the TeamFunctionality">
+      <created>1686421492928</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1686421492928</updated>
+    </task>
+    <option name="localTasksCounter" value="3" />
+    <servers />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="This commit includes significant changes across multiple files in the project. The primary focus of these changes was refactoring the code to enhance its structure, readability, and maintainability. Additionally, comprehensive Javadoc comments were added to provide detailed documentation for the classes and methods involved." />
+    <MESSAGE value="I implemented the TeamFunctionality" />
+    <option name="LAST_COMMIT_MESSAGE" value="I implemented the TeamFunctionality" />
+  </component>
+</project>

--- a/src/main/java/me/daniel/bedwarsplugin/BedWarsPlugin.java
+++ b/src/main/java/me/daniel/bedwarsplugin/BedWarsPlugin.java
@@ -9,8 +9,11 @@ import me.daniel.bedwarsplugin.model.BlockDeleter;
 import me.daniel.bedwarsplugin.model.TeamManager;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 import org.bukkit.command.PluginCommand;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Objects;
 
 /**
  * Author: Daniel Dmytryszyn & Jakob Zeise
@@ -33,6 +36,7 @@ public final class BedWarsPlugin extends JavaPlugin {
 
         registerListeners();
         registerCommands();
+        Objects.requireNonNull(getServer().getWorld("world")).setGameRule(GameRule.DO_IMMEDIATE_RESPAWN, true);
 
     }
 
@@ -48,17 +52,24 @@ public final class BedWarsPlugin extends JavaPlugin {
 
 
     /**
+     *
      * Registers the listeners.
      */
     public void registerListeners() {
-        getServer().getPluginManager().registerEvents(new OnBlockDestroyEvent(blockDeleter), this);
+        getServer().getPluginManager().registerEvents(new OnBlockDestroyEvent(blockDeleter, teamManager), this);
+        getServer().getPluginManager().registerEvents(new OnBlockPlaceEvent(blockDeleter), this);
+
+        getServer().getPluginManager().registerEvents(new OnTrapdoorInteractEvent(), this);
         getServer().getPluginManager().registerEvents(new OnFallEvent(), this);
         getServer().getPluginManager().registerEvents(new OnMergeEvent(), this);
         getServer().getPluginManager().registerEvents(new OnBuyEvent(), this);
+        getServer().getPluginManager().registerEvents(new OnBedClickEvent(), this);
+
         getServer().getPluginManager().registerEvents(new OnShopOpenEvent(ShopItemsReader.getShopItems()), this);
+        getServer().getPluginManager().registerEvents(new OnVillagerHitEvent(), this);
 
         getServer().getPluginManager().registerEvents(new OnLeaveEvent(teamManager), this);
-        getServer().getPluginManager().registerEvents(new OnRespawnEvent(teamManager), this);
+        getServer().getPluginManager().registerEvents(new OnRespawnEvent(teamManager, this), this);
         getServer().getPluginManager().registerEvents(new OnJoinEvent(teamManager), this);
 
     }

--- a/src/main/java/me/daniel/bedwarsplugin/data/ItemSpawnerReader.java
+++ b/src/main/java/me/daniel/bedwarsplugin/data/ItemSpawnerReader.java
@@ -26,7 +26,7 @@ public class ItemSpawnerReader {
      */
     public static List<ItemSpawner> getItemSpawner(World world) {
 
-        String testFile = "35,114,1,EMERALD;35,124,1,EMERALD;57,115,-7,EMERALD";
+        String testFile = "35,114,1,EMERALD;35,124,1,EMERALD;57,115,-7,EMERALD;-47,120,4,EMERALD;41,120,-83,EMERALD;125,120,4,EMERALD;41,120,79,EMERALD";
 
         if (spawners != null) {
             return spawners;

--- a/src/main/java/me/daniel/bedwarsplugin/data/ShopItemsReader.java
+++ b/src/main/java/me/daniel/bedwarsplugin/data/ShopItemsReader.java
@@ -25,7 +25,9 @@ public class ShopItemsReader {
         items.add(new ShopItem(new ItemStack(Material.ARROW), 1, 8));
         items.add(new ShopItem(new ItemStack(Material.BLUE_WOOL), 1, 16));
         items.add(new ShopItem(new ItemStack(Material.DIAMOND_PICKAXE), 5, 1));
-        items.add(new ShopItem(new ItemStack(Material.DIAMOND_SWORD), 20, 1));
+        items.add(new ShopItem(new ItemStack(Material.DIAMOND_HOE), 1, 1));
+        items.add(new ShopItem(new ItemStack(Material.LEAD), 1, 1));
+        items.add(new ShopItem(new ItemStack(Material.DONKEY_SPAWN_EGG), 1, 1));
 
         return items;
     }

--- a/src/main/java/me/daniel/bedwarsplugin/data/TeamsDataReader.java
+++ b/src/main/java/me/daniel/bedwarsplugin/data/TeamsDataReader.java
@@ -5,6 +5,8 @@ import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +33,19 @@ public class TeamsDataReader {
                 greenColor.getBlue()
         );
 
-        Location bedLocationGreen = new Location(Bukkit.getWorlds().get(0), 41, 121, 60);
-        teams.add(new Team(greenTextColor, greenColor, bedLocationGreen, new ArrayList<>(), "Green"));
+        Location bedHeadLocationGreen = new Location(Bukkit.getWorlds().get(0), 41, 121, 60);
+        Location bedFootLocationGreen = new Location(Bukkit.getWorlds().get(0), 41, 121, 61);
+        
+        teams.add(new Team(
+                greenTextColor,
+                greenColor,
+                bedHeadLocationGreen,
+                bedFootLocationGreen,
+                "Green",
+                new Location(Bukkit.getWorlds().get(0), 52, 204, 2),
+                Material.GREEN_BED,
+                BlockFace.NORTH
+        ));
 
 
         Color yellowColor = Color.YELLOW;
@@ -42,8 +55,19 @@ public class TeamsDataReader {
                 yellowColor.getBlue()
         );
 
-        Location bedLocationYellow = new Location(Bukkit.getWorlds().get(0), -34, 121, 4);
-        teams.add(new Team(yellowTextColor, yellowColor, bedLocationYellow, new ArrayList<>(), "Yellow"));
+        Location bedHeadLocationYellow = new Location(Bukkit.getWorlds().get(0), -33, 121, 4);
+        Location bedFootLocationYellow = new Location(Bukkit.getWorlds().get(0), -34, 121, 4);
+        teams.add(new Team(
+                yellowTextColor,
+                yellowColor,
+                bedHeadLocationYellow,
+                bedFootLocationYellow,
+                "Yellow",
+                new Location(Bukkit.getWorlds().get(0), -34, 121, 4),
+                Material.YELLOW_BED,
+                BlockFace.EAST
+
+        ));
 
 
         Color redColor = Color.RED;
@@ -54,18 +78,38 @@ public class TeamsDataReader {
         );
 
 
-        Location bedLocationRed = new Location(Bukkit.getWorlds().get(0), 41, 121, -45);
-        teams.add(new Team(redTextColor, redColor, bedLocationRed, new ArrayList<>(), "Red"));
+        Location bedHeadLocationRed = new Location(Bukkit.getWorlds().get(0), 41, 121, -65);
+        Location bedFootLocationRed = new Location(Bukkit.getWorlds().get(0), 41, 121, -66);
+        teams.add(new Team(
+                redTextColor,
+                redColor,
+                bedHeadLocationRed,
+                bedFootLocationRed,
+                "Red",
+                new Location(Bukkit.getWorlds().get(0), 41, 121, -45),
+                Material.RED_BED,
+                BlockFace.SOUTH
+        ));
 
 
-        Color blueColor = Color.AQUA;
+        Color blueColor = Color.BLUE;
         TextColor blueTextColor = TextColor.color(
                 blueColor.getRed(),
                 blueColor.getGreen(),
                 blueColor.getBlue()
         );
-        Location bedLocationAqua = new Location(Bukkit.getWorlds().get(0), 114, 121, 4);
-        teams.add(new Team(blueTextColor, blueColor, bedLocationAqua, new ArrayList<>(), "Blue"));
+        Location bedHeadLocationBlue = new Location(Bukkit.getWorlds().get(0), 113, 121, 4);
+        Location bedFootLocationBlue = new Location(Bukkit.getWorlds().get(0), 114, 121, 4);
+        teams.add(new Team(
+                blueTextColor,
+                blueColor,
+                bedHeadLocationBlue,
+                bedFootLocationBlue,
+                "Blue",
+                new Location(Bukkit.getWorlds().get(0), 113, 121, 4),
+                Material.BLUE_BED,
+                BlockFace.WEST
+        ));
 
         return teams;
 

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnBedClickEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnBedClickEvent.java
@@ -1,0 +1,19 @@
+package me.daniel.bedwarsplugin.listener;
+
+import com.destroystokyo.paper.event.player.PlayerSetSpawnEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+/**
+ * Author:
+ */
+public class OnBedClickEvent implements Listener {
+
+    @EventHandler
+    public void onBedClick(PlayerSetSpawnEvent event) {
+        event.setCancelled(true);
+    }
+
+
+
+}

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockPlaceEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnBlockPlaceEvent.java
@@ -3,6 +3,7 @@ package me.daniel.bedwarsplugin.listener;
 import me.daniel.bedwarsplugin.model.BlockDeleter;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 
@@ -24,6 +25,7 @@ public class OnBlockPlaceEvent implements Listener {
      *
      * @param event the event
      */
+    @EventHandler
     public void onBlockPlaceEvent(BlockPlaceEvent event) {
 
         Player player = event.getPlayer();

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnDeathEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnDeathEvent.java
@@ -1,0 +1,30 @@
+package me.daniel.bedwarsplugin.listener;
+
+
+import me.daniel.bedwarsplugin.model.Team;
+import me.daniel.bedwarsplugin.model.TeamManager;
+import org.bukkit.GameMode;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+public class OnDeathEvent implements Listener {
+
+    private final TeamManager teamManager;
+
+    public OnDeathEvent(TeamManager teamManager) {
+        this.teamManager = teamManager;
+    }
+
+    @EventHandler
+    public void onDeathEvent(PlayerDeathEvent event) {
+        Player player = event.getPlayer();
+
+        Team team = teamManager.getTeamOfPlayer(player);
+
+        if (!team.hasBed()) {
+            player.setGameMode(GameMode.ADVENTURE);
+        }
+    }
+}

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnRespawnEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnRespawnEvent.java
@@ -1,12 +1,19 @@
 package me.daniel.bedwarsplugin.listener;
 
+import me.daniel.bedwarsplugin.BedWarsPlugin;
 import me.daniel.bedwarsplugin.model.Team;
 import me.daniel.bedwarsplugin.model.TeamManager;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.concurrent.Delayed;
 
 /**
  * Author: Jakob Zeise
@@ -14,15 +21,16 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 public class OnRespawnEvent implements Listener {
 
     private final TeamManager teamManager;
-
+    private final Plugin plugin;
 
     /**
      * Constructs an OnSpawnEvent object.
      *
      * @param teamManager the team manager
      */
-    public OnRespawnEvent(TeamManager teamManager) {
+    public OnRespawnEvent(TeamManager teamManager, Plugin plugin) {
         this.teamManager = teamManager;
+        this.plugin = plugin;
     }
 
 
@@ -33,15 +41,23 @@ public class OnRespawnEvent implements Listener {
      */
     @EventHandler
     public void onRespawnEvent(PlayerRespawnEvent event) {
-        System.out.println("Player respawned!");
 
         Player player = event.getPlayer();
 
         Team team = teamManager.getTeamOfPlayer(player);
 
-        Location bedLocation = team.getBedLocation();
-        player.teleport(bedLocation);
+        if (!team.hasBed()) {
+            player.setGameMode(GameMode.SPECTATOR);
+            return;
+        }
+
+        Bukkit.getScheduler().runTaskLater(plugin, () -> player.teleport(team.getBedLocation()), 5L * 20);
+
+        event.setRespawnLocation(team.getSpawnLocation());
 
     }
 
+
 }
+
+

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnTrapdoorInteractEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnTrapdoorInteractEvent.java
@@ -1,0 +1,28 @@
+package me.daniel.bedwarsplugin.listener;
+
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.Objects;
+
+public class OnTrapdoorInteractEvent implements Listener {
+
+    @EventHandler
+    public void onTrapdoorInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        if (player.getGameMode() == GameMode.CREATIVE){
+            return;
+        }
+        if (Objects.requireNonNull(event.getClickedBlock()).getType() == Material.OAK_TRAPDOOR){
+            event.setCancelled(true);
+        }
+
+    }
+
+
+}

--- a/src/main/java/me/daniel/bedwarsplugin/listener/OnVillagerHitEvent.java
+++ b/src/main/java/me/daniel/bedwarsplugin/listener/OnVillagerHitEvent.java
@@ -1,0 +1,26 @@
+package me.daniel.bedwarsplugin.listener;
+
+import org.bukkit.entity.Villager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+
+/**
+ * Author: Daniel Dmytryszyn
+ */
+public class OnVillagerHitEvent implements Listener {
+
+    /**
+     * This event is used to cancel damage to villagers
+     */
+    @EventHandler
+    public void onVillagerHit(EntityDamageEvent event) {
+
+        if (event.getEntity() instanceof Villager){
+            event.setCancelled(true);
+        }
+
+    }
+
+}

--- a/src/main/java/me/daniel/bedwarsplugin/model/BlockDeleter.java
+++ b/src/main/java/me/daniel/bedwarsplugin/model/BlockDeleter.java
@@ -50,4 +50,8 @@ public class BlockDeleter {
         }
         blocksPlaced.clear();
     }
+
+    public List<Location> getBlocksPlaced() {
+        return blocksPlaced;
+    }
 }

--- a/src/main/java/me/daniel/bedwarsplugin/model/Team.java
+++ b/src/main/java/me/daniel/bedwarsplugin/model/Team.java
@@ -5,8 +5,12 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -18,28 +22,45 @@ public class Team {
 
     private final TextColor textColor;
     private final Color color;
-    private final Location bedLocation;
+    private final Location bedHeadLocation;
+    private final Location bedFootLocation;
     private final List<Player> players;
     private boolean hasBed;
-
+    private Location spawnLocation;
     private final String name;
+    private final Material bedMaterial;
+    private final BlockFace bedDirection;
 
     /**
-     * Constructs a Team object.
      *
-     * @param color       The color of the team.
-     * @param color1
-     * @param bedLocation The location of the bed.
-     * @param players     The players in the team.
-     * @param name        The name of the team.
+     * @param color The color of the team.
+     * @param color1 The color of the team.
+     * @param bedHeadLocation The location of the head of the bed.
+     * @param bedFootLocation   The location of the foot of the bed.
+     * @param name The name of the team.
+     * @param spawnLocation The location where the players of the team spawn.
+     * @param bedMaterial The material of the bed.
      */
-    public Team(TextColor color, Color color1, Location bedLocation, List<Player> players, String name) {
+    public Team(
+            TextColor color,
+            Color color1,
+            Location bedHeadLocation,
+            Location bedFootLocation,
+            String name,
+            Location spawnLocation,
+            Material bedMaterial,
+            BlockFace bedDirection
+    ) {
         this.textColor = color;
         this.color = color1;
-        this.bedLocation = bedLocation;
-        this.players = players;
+        this.bedHeadLocation = bedHeadLocation;
+        this.bedFootLocation = bedFootLocation;
+        this.players = new ArrayList<>();
         this.name = name;
         this.hasBed = true;
+        this.spawnLocation = spawnLocation;
+        this.bedMaterial = bedMaterial;
+        this.bedDirection = bedDirection;
     }
 
 
@@ -85,7 +106,7 @@ public class Team {
      * @return the bed location
      */
     public Location getBedLocation() {
-        return bedLocation;
+        return bedHeadLocation;
     }
 
     /**
@@ -119,9 +140,33 @@ public class Team {
 
     public void destroyBed() {
         hasBed = false;
+        players.forEach(player -> {
+            player.playSound(player.getLocation(), Sound.ENTITY_LIGHTNING_BOLT_IMPACT, 1.0f, 1.0f);
+            player.sendMessage(Component.text("Your bed has been destroyed!!!!!!!"));
+        });
+
     }
     public boolean hasBed() {
         return hasBed;
     }
 
+    public Location getSpawnLocation() {
+        return spawnLocation;
+    }
+
+    public Material getBedMaterial() {
+        return bedMaterial;
+    }
+
+    public Location getBedFootLocation() {
+        return bedFootLocation;
+    }
+
+    public Location getBedHeadLocation() {
+        return bedHeadLocation;
+    }
+
+    public BlockFace getBedDirection() {
+        return bedDirection;
+    }
 }

--- a/src/main/java/me/daniel/bedwarsplugin/model/TeamManager.java
+++ b/src/main/java/me/daniel/bedwarsplugin/model/TeamManager.java
@@ -1,6 +1,7 @@
 package me.daniel.bedwarsplugin.model;
 
 import me.daniel.bedwarsplugin.data.TeamsDataReader;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
 import java.util.List;
@@ -68,6 +69,19 @@ public class TeamManager {
     public void removePlayer(Player player) {
         Team team = getTeamOfPlayer(player);
         team.removePlayer(player);
+    }
+
+    public List<Location> getBedLocations() {
+        return teams.stream().map(Team::getBedLocation).toList();
+    }
+
+    public Team getTeamByBedLocation(Location location) {
+        for (Team team : teams) {
+            if (team.getBedLocation().equals(location)) {
+                return team;
+            }
+        }
+        return null;
     }
 
 }


### PR DESCRIPTION
This pull request implements the bed spawn functionality in the BedWars plugin. It includes the following changes:

- Added bed spawn logic in the Main class.
- Registered event listeners for block interactions, trapdoor interactions, falls, merges, and buying items.
- Implemented bed replacement logic in the StartRoundCommand.
- Added methods to clear player inventory and reset health and food levels.
- Updated the ItemSpawnerReader and ShopItemsReader with new data.
- Modified the TeamsDataReader to include bed foot and head locations.
- Created a new event listener for cancelling the PlayerSetSpawnEvent when clicking on a bed.

These changes allow players to respawn at their team's bed location when they die during a round. Additionally, the beds are replaced with the respective team's bed material at the start of each round.

Please review and merge this pull request if it meets the project's requirements. Thank you!

